### PR TITLE
upgrade to STIR 4.0.0-alpha

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "STIR" %}
-{% set version = "4.0.0.alpha" %}
+{% set version = "4.0.0a0" %}
 {% set git_tag = "stir_rel_4_00_alpha" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "STIR" %}
-{% set version = "4.0.0-alpha" %}
+{% set version = "4.0.0.alpha" %}
 {% set git_tag = "stir_rel_4_00_alpha" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
 
 {% set name = "STIR" %}
 {% set version = "4.0.0a0" %}
-{% set git_tag = "stir_rel_4_00_alpha" %}
+{% set sha256 = "0dd7d44b401ecca12298dbf180fb94fc59dcb93315bdb2a8a1141708f7188c1a" %}
+{% set treehash = "stir_rel_4_00_alpha" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  git_url: https://github.com/UCL/STIR.git
-  git_rev: {{ git_tag }}
-  git_depth: 1000 # (Defaults to -1/not shallow), has to be large enough such that the tag is actually in the last xxx commits
+  fn: {{ name }}-{{ treehash }}.tar.gz
+  url: https://github.com/UCL/{{ name }}/archive/{{ treehash }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   skip: true  # [py2k]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 source:
   git_url: https://github.com/UCL/STIR.git
   git_rev: {{ git_tag }}
-  git_depth: 1 # (Defaults to -1/not shallow)
+  git_depth: 1000 # (Defaults to -1/not shallow), has to be large enough such that the tag is actually in the last xxx commits
 
 build:
   skip: true  # [py2k]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,23 @@
 
 {% set name = "STIR" %}
-{% set version = "3.0.1.dev2" %}
-{% set sha256 = "5a8be0cf3374118168203ccffc2198ab306a4d13d5412600660125c7a29439e8" %}
-{% set treehash = "course_MIC2018" %}
+{% set version = "4.0.0-alpha" %}
+{% set git_tag = "stir_rel_4_00_alpha" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ treehash }}.zip
-  url: https://github.com/UCL/{{ name }}/archive/{{ treehash }}.zip
-  sha256: {{ sha256 }}
+  git_url: https://github.com/UCL/STIR.git
+  git_rev: {{ git_tag }}
+  git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
   skip: true  # [py2k]
   skip: true  # [win and py<36]
   skip: true  # [win]
   skip: true  # [osx]
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
also use git as opposed to zip to avoid  having to compute sha256

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
