### PR TITLE
BUG: Run/build with the same version of libitk

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,11 +34,12 @@ requirements:
     - numpy
     - swig
     - libitk-devel
+    - libitk
     - openmp  # [osx]
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - libitk
+    - {{ pin_compatible('libitk', min_pin='x.x', max_pin='x.x') }}
     - openmp  # [osx]
 
 test:


### PR DESCRIPTION
Because libitk doesn't use the standard links/versioned shared libraries, we need to ensure that the same major/minor version is used at build and install time.

Closes #34

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
