### PR TITLE
remove itk version restrictions except for Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
     - numpy
     - swig
     - libitk-devel
-    - libitk <5.2
+    - libitk <5.2  # [win]
+    - libitk  # [not win]
     - root_base  # [linux]
     - nlohmann_json
     - openmp  # [osx]


### PR DESCRIPTION
As we had problems in #35  with ITK 5.2 only on Windows, attempt to remove the version restriction for other OSs