### PR TITLE
 dev: re-enable OSX, including ROOT

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,54 +8,103 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.34.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.36.04
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.34.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.36.04
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.34.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.36.04
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.34.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313:
-        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313
+      linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.36.04
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.34.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.36.04
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpython:
-        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpython
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.34.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313:
-        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.36.04
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.34.10:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.36.04:
+        CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+    maxParallel: 23
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,83 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-15
+  strategy:
+    matrix:
+      osx_64_python3.10.____cpythonroot_base6.34.10:
+        CONFIG: osx_64_python3.10.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.10.____cpythonroot_base6.36.04:
+        CONFIG: osx_64_python3.10.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.11.____cpythonroot_base6.34.10:
+        CONFIG: osx_64_python3.11.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.11.____cpythonroot_base6.36.04:
+        CONFIG: osx_64_python3.11.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.12.____cpythonroot_base6.34.10:
+        CONFIG: osx_64_python3.12.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.12.____cpythonroot_base6.36.04:
+        CONFIG: osx_64_python3.12.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.13.____cp313root_base6.34.10:
+        CONFIG: osx_64_python3.13.____cp313root_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.13.____cp313root_base6.36.04:
+        CONFIG: osx_64_python3.13.____cp313root_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.10.____cpythonroot_base6.34.10:
+        CONFIG: osx_arm64_python3.10.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.10.____cpythonroot_base6.36.04:
+        CONFIG: osx_arm64_python3.10.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.11.____cpythonroot_base6.34.10:
+        CONFIG: osx_arm64_python3.11.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.11.____cpythonroot_base6.36.04:
+        CONFIG: osx_arm64_python3.11.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.12.____cpythonroot_base6.34.10:
+        CONFIG: osx_arm64_python3.12.____cpythonroot_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.12.____cpythonroot_base6.36.04:
+        CONFIG: osx_arm64_python3.12.____cpythonroot_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.13.____cp313root_base6.34.10:
+        CONFIG: osx_arm64_python3.13.____cp313root_base6.34.10
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.13.____cp313root_base6.36.04:
+        CONFIG: osx_arm64_python3.13.____cp313root_base6.36.04
+        UPLOAD_PACKAGES: 'True'
+    maxParallel: 15
+  timeoutInMinutes: 360
+  variables: {}
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      export CI=azure
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
+      export OSX_FORCE_SDK_DOWNLOAD="1"
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+        export IS_PR_BUILD="True"
+      else
+        export IS_PR_BUILD="False"
+      fi
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -44,6 +44,7 @@ jobs:
       win_64_cuda_compiler_versionNonepython3.13.____cp313:
         CONFIG: win_64_cuda_compiler_versionNonepython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+    maxParallel: 12
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.36.04.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- '12.9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -33,9 +33,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.10.* *_cpython
 root_base:
-- 6.34.10
 - 6.36.04
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.34.10.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -33,10 +33,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
 root_base:
 - 6.34.10
-- 6.36.04
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.36.04.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -33,9 +33,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.13.* *_cp313
 root_base:
-- 6.34.10
 - 6.36.04
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.36.04.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -33,9 +33,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.12.* *_cpython
 root_base:
-- 6.34.10
 - 6.36.04
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.36.04.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.36.04
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.34.10.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- '13.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -33,10 +33,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.10.* *_cpython
 root_base:
 - 6.34.10
-- 6.36.04
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.36.04.yaml
@@ -33,9 +33,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 root_base:
-- 6.34.10
 - 6.36.04
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.36.04.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- '13.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -33,9 +33,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.12.* *_cpython
 root_base:
-- 6.34.10
 - 6.36.04
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.34.10.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.34.10.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.34.10
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.36.04.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.36.04.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.36.04
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/osx_64_python3.10.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/osx_64_python3.10.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.10.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/osx_64_python3.10.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.11.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/osx_64_python3.11.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.11.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/osx_64_python3.11.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.12.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/osx_64_python3.12.____cpythonroot_base6.34.10.yaml
@@ -1,11 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,19 +17,21 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 hdf5:
 - 1.14.6
 libboost_headers:
 - '1.88'
 libitk_devel:
 - '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,14 +39,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
 root_base:
 - 6.34.10
-- 6.36.04
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_python3.12.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/osx_64_python3.12.____cpythonroot_base6.36.04.yaml
@@ -1,11 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,19 +17,21 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 hdf5:
 - 1.14.6
 libboost_headers:
 - '1.88'
 libitk_devel:
 - '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,14 +39,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 root_base:
-- 6.34.10
 - 6.36.04
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_python3.13.____cp313root_base6.34.10.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313root_base6.34.10.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.34.10
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.13.____cp313root_base6.36.04.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313root_base6.36.04.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.36.04
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.10.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonroot_base6.34.10.yaml
@@ -1,11 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.28'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,19 +17,21 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 hdf5:
 - 1.14.6
 libboost_headers:
 - '1.88'
 libitk_devel:
 - '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,14 +39,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 root_base:
 - 6.34.10
-- 6.36.04
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cuda_compiler_version

--- a/.ci_support/osx_arm64_python3.10.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.11.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonroot_base6.34.10.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+root_base:
+- 6.34.10
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.11.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonroot_base6.36.04.yaml
@@ -1,11 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +19,19 @@ cuda_compiler:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 hdf5:
 - 1.14.6
 libboost_headers:
 - '1.88'
 libitk_devel:
 - '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,12 +41,9 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 root_base:
-- 6.34.10
 - 6.36.04
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cuda_compiler_version

--- a/.ci_support/osx_arm64_python3.12.____cpythonroot_base6.34.10.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonroot_base6.34.10.yaml
@@ -1,11 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +19,19 @@ cuda_compiler:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 hdf5:
 - 1.14.6
 libboost_headers:
 - '1.88'
 libitk_devel:
 - '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,14 +39,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 root_base:
 - 6.34.10
-- 6.36.04
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cuda_compiler_version

--- a/.ci_support/osx_arm64_python3.12.____cpythonroot_base6.36.04.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonroot_base6.36.04.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+root_base:
+- 6.36.04
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.13.____cp313root_base6.34.10.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313root_base6.34.10.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.34.10
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.13.____cp313root_base6.36.04.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313root_base6.36.04.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge stir_dev
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+hdf5:
+- 1.14.6
+libboost_headers:
+- '1.88'
+libitk_devel:
+- '5.4'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+root_base:
+- 6.36.04
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# -*- mode: jinja-shell -*-
+
+source .scripts/logging_utils.sh
+
+set -xe
+
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
+
+( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
+MICROMAMBA_VERSION="1.5.10-0"
+if [[ "$(uname -m)" == "arm64" ]]; then
+  osx_arch="osx-arm64"
+else
+  osx_arch="osx-64"
+fi
+MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
+MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
+echo "Downloading micromamba ${MICROMAMBA_VERSION}"
+micromamba_exe="$(mktemp -d)/micromamba"
+curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
+chmod +x "${micromamba_exe}"
+echo "Creating environment"
+"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
+  --channel conda-forge \
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
+mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
+echo "Cleaning up micromamba"
+rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
+( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+echo "Activating environment"
+source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
+conda activate base
+export CONDA_SOLVER="libmamba"
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
+
+
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ "${CI:-}" != "" ]]; then
+  mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+fi
+
+if [[ "${CI:-}" != "" ]]; then
+  echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+  /usr/bin/sudo mangle_homebrew
+  /usr/bin/sudo -k
+else
+  echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
+
+if [[ "${sha:-}" == "" ]]; then
+  sha=$(git rev-parse HEAD)
+fi
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+
+( endgroup "Configuring conda" ) 2> /dev/null
+
+echo -e "\n\nMaking the build clobber file"
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
+
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+    # Drop into an interactive shell
+    /bin/bash
+else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
+    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
+        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir ./recipe -m ./.ci_support/${CONFIG}.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
+      upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
+fi

--- a/README.md
+++ b/README.md
@@ -40,87 +40,283 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.34.10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.34.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.36.04</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonroot_base6.36.04" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.34.10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.34.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.36.04</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonroot_base6.36.04" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.34.10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.34.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.36.04</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonroot_base6.36.04" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.34.10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.34.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.36.04</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313root_base6.36.04" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.34.10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.34.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.36.04</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonroot_base6.36.04" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpython</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.34.10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.34.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.36.04</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313root_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313root_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.10.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.10.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.10.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.10.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.11.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.11.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.11.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.11.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.12.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.12.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.12.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.12.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.13.____cp313root_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.13.____cp313root_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.13.____cp313root_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.13.____cp313root_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.10.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.10.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.10.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.10.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.11.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.11.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.11.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.11.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.12.____cpythonroot_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.12.____cpythonroot_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.12.____cpythonroot_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.12.____cpythonroot_base6.36.04" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.13.____cp313root_base6.34.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.13.____cp313root_base6.34.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.13.____cp313root_base6.36.04</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6240&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/stir-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.13.____cp313root_base6.36.04" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,4 +29,5 @@ stages:
   dependsOn: Check
   jobs:
     - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml
     - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,9 @@ OS=`uname`
 case $OS in
   'Darwin')
     EXTRA_OPTS="-DDISABLE_HDF5:BOOL=OFF"
+    # see https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk 
+    CXXFLAGS="-D_LIBCPP_DISABLE_AVAILABILITY"
+    export CXXFLAGS
     ;;
   *)
     EXTRA_OPTS="-DDISABLE_HDF5:BOOL=OFF"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% if cuda_compiler_version != "None" %}
 {% set build_number = build_number + 200 %}
 {% endif %}
-{% set dev_number = 0 %}
+{% set dev_number = 1 %}
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
 {% set cuda_major = 0 %}
@@ -28,8 +28,6 @@ build:
   {% if cuda_major == 11 %}
   skip: true  # [win]
   {% endif %}
-  # skipping osx due to STIR issues #1490, 1491, 1494
-  skip: true  # [osx]
   ignore_run_exports:
     - cudatoolkit
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,11 +68,8 @@ requirements:
     {% endif %}
     - libparallelproj
     # Recent ROOT needs C++ 20, but CUDA 11 doesn't support it
-    # osx-arm skipped due to https://github.com/conda-forge/root-feedstock/issues/260
-    # Python 3.12 not yet supported in ROOT
-    # Note: these conditions have to be replicated in the test section
     {% if cuda_major != 11 %}
-    - root_base  # [not (py==312 or win or (osx and arm64))]
+    - root_base  # [not win]
     {% endif %}
     - zlib  # [win]
   run:
@@ -105,7 +102,7 @@ test:
     - ./run_tests.sh --nointbp  # [not win]
     - ./run_test_zoom_image.sh  # [not win]
     {% if cuda_major != 11 %}
-    - ./run_root_GATE.sh        # [not (py==312 or win or (osx and arm64))]
+    - ./run_root_GATE.sh        # [not win]
     {% endif %}
     - run_tests  # [win]
     - cd SPECT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ package:
 
 source:
   git_url: https://github.com/UCL/STIR.git
-  git_rev: aef367525cd6295d2e825f442e461bef1bc8b28f
+  # 07Oct2025
+  git_rev: 209db3c72c05e2d9610797d68fa15248b5254921
   git_depth: 200
 
 build:


### PR DESCRIPTION
Now that STIR works for clang on OSX, re-enable it.](https://github.com/conda-forge/stir-feedstock/pull/143)